### PR TITLE
fix: handle expected date string from Eleventy in formatDate filter

### DIFF
--- a/src/filters/format-date-filter.js
+++ b/src/filters/format-date-filter.js
@@ -20,7 +20,7 @@ const getOrdinal = function (n) {
 };
 
 module.exports = function dateFilter(value) {
-    const dateObject = new Date(value);
+    const dateObject = new Date(new Date(value).toUTCString());
 
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 

--- a/src/filters/format-date-filter.js
+++ b/src/filters/format-date-filter.js
@@ -20,11 +20,9 @@ const getOrdinal = function (n) {
 };
 
 module.exports = function dateFilter(value) {
-    let [y, m, d] = value.split("-");
-    m = parseInt(m, 10);
-    d = parseInt(d, 10);
+    const dateObject = new Date(value);
 
     const months = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 
-    return `${months[m - 1]} ${getOrdinal(d)}, ${y}`;
+    return `${months[dateObject.getMonth()]} ${getOrdinal(dateObject.getDate())}, ${dateObject.getFullYear()}`;
 };

--- a/test/format-date.test.js
+++ b/test/format-date.test.js
@@ -15,5 +15,5 @@ const test = require("ava");
 const formatDateFilter = require("../src/filters/format-date-filter.js");
 
 test("Formats date properly", function (t) {
-    t.is(formatDateFilter("2020-01-01"), "January 1st, 2020");
+    t.is(formatDateFilter("Sun Jun 21 2020 21:00:00 GMT-0300 (Atlantic Daylight Time)"), "June 21st, 2020");
 });

--- a/test/format-date.test.js
+++ b/test/format-date.test.js
@@ -14,6 +14,6 @@ https://github.com/fluid-project/eleventy-plugin-fluid/raw/main/LICENSE.md.
 const test = require("ava");
 const formatDateFilter = require("../src/filters/format-date-filter.js");
 
-test("Formats date properly", function (t) {
-    t.is(formatDateFilter("Sun Jun 21 2020 21:00:00 GMT-0300 (Atlantic Daylight Time)"), "June 21st, 2020");
+test("Formats local date properly", function (t) {
+    t.is(formatDateFilter("Sun Jun 21 2020 18:00:00 GMT-0300 (Atlantic Daylight Time)"), "June 21st, 2020");
 });


### PR DESCRIPTION
Eleventy turns dates into a string like this when outputting them in a template (docs: https://www.11ty.dev/docs/dates/#example):

`Sun Dec 31 2017 18:00:00 GMT-0600 (Central Standard Time)`

This PR updates the `formatDate` filter to properly handle this input for date formatting.
