### PR TITLE
feat: use configured input and output paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 coverage
-dist
+_site
 fixtures/locales/*.js
 node_modules
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,7 @@
 .github
 .husky
+_site
 coverage
-dist
 fixtures
 test
 .commitlintrc.json

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for CSS files to process? */
-    basePath: "./src/assets/styles",
+    basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
     /* Should CSS files be processed? */
     enabled: true,
     /* See: https://lightningcss.dev/minification.html */
@@ -139,7 +139,7 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for Sass files to process? */
-    basePath: "./src/assets/styles",
+    basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
     /* Should Sass files be processed? */
     enabled: false,
     /* See: https://lightningcss.dev/minification.html */
@@ -189,14 +189,14 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for JavaScript files to process? */
-    basePath: "./src/assets/scripts",
+    basePath: `${eleventyConfig.dir.input || "./src"}/assets/scripts`,
     /* Should JavaScript files be processed? */
     enabled: true,
     /* See: https://esbuild.github.io/api/#minify */
     minify: true,
     /* See: https://esbuild.github.io/content-types/#javascript */
     target: "es2020",
-    outdir: "./dist/assets/scripts"
+    basePath: `${eleventyConfig.dir.output || "./_site"}/assets/scripts`
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for CSS files to process? */
-    basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
+    basePath: `./${eleventyConfig.dir.input || "src"}/assets/styles`,
     /* Should CSS files be processed? */
     enabled: true,
     /* See: https://lightningcss.dev/minification.html */
@@ -139,7 +139,7 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for Sass files to process? */
-    basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
+    basePath: `./${eleventyConfig.dir.input || "src"}/assets/styles`,
     /* Should Sass files be processed? */
     enabled: false,
     /* See: https://lightningcss.dev/minification.html */
@@ -189,14 +189,14 @@ Default values are as follows:
 ```js
 let options = {
     /* Where should Eleventy look for JavaScript files to process? */
-    basePath: `${eleventyConfig.dir.input || "./src"}/assets/scripts`,
+    basePath: `./${eleventyConfig.dir.input || "src"}/assets/scripts`,
     /* Should JavaScript files be processed? */
     enabled: true,
     /* See: https://esbuild.github.io/api/#minify */
     minify: true,
     /* See: https://esbuild.github.io/content-types/#javascript */
     target: "es2020",
-    basePath: `${eleventyConfig.dir.output || "./_site"}/assets/scripts`
+    basePath: `./${eleventyConfig.dir.output || "_site"}/assets/styles`
 };
 ```
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -13,7 +13,7 @@ https://github.com/fluid-project/eleventy-plugin-fluid/raw/main/LICENSE.md.
 
 const fluidPlugin = require("./index.js");
 
-const inputPath = "./fixtures";
+const inputPath = "fixtures";
 
 module.exports = function (eleventyConfig) {
     eleventyConfig.addPlugin(fluidPlugin, {

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -17,17 +17,9 @@ const inputPath = "./fixtures";
 
 module.exports = function (eleventyConfig) {
     eleventyConfig.addPlugin(fluidPlugin, {
-        css: {
-            basePath: `${inputPath}/assets/styles`
-        },
         sass: {
-            basePath: `${inputPath}/assets/styles`,
             enabled: true
         },
-        js: {
-            basePath: `${inputPath}/assets/scripts`
-        },
-        localesDirectory: `${inputPath}/locales`,
         supportedLanguages: {
             de: {
                 slug: "de",
@@ -47,8 +39,7 @@ module.exports = function (eleventyConfig) {
 
     return {
         dir: {
-            input: inputPath,
-            output: "dist"
+            input: inputPath
         },
         passthroughFileCopy: true
     };

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
                 plugins: []
             },
             css: {
-                basePath: "./src/assets/styles",
+                basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
                 enabled: true,
                 minify: true,
                 sourceMap: false,
@@ -56,7 +56,7 @@ module.exports = {
                 browserslist: "> 1%"
             },
             sass: {
-                basePath: "./src/assets/styles",
+                basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
                 enabled: false,
                 minify: true,
                 sourceMap: false,
@@ -66,15 +66,15 @@ module.exports = {
                 browserslist: "> 1%"
             },
             js: {
-                basePath: "./src/assets/scripts",
+                basePath: `${eleventyConfig.dir.input || "./src"}/assets/scripts`,
                 enabled: true,
                 minify: true,
                 target: "es2020",
-                outdir: "./dist/assets/scripts"
+                outdir: `${eleventyConfig.dir.output || "./_site"}/assets/scripts`
             },
             supportedLanguages: languages,
             defaultLanguage: "en",
-            localesDirectory: "./src/locales",
+            localesDirectory: `${eleventyConfig.dir.input || "./src"}/locales`,
             templateFormats: [
                 "html",
                 "md",

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = {
                 plugins: []
             },
             css: {
-                basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
+                basePath: `./${eleventyConfig.dir.input || "src"}/assets/styles`,
                 enabled: true,
                 minify: true,
                 sourceMap: false,
@@ -56,7 +56,7 @@ module.exports = {
                 browserslist: "> 1%"
             },
             sass: {
-                basePath: `${eleventyConfig.dir.input || "./src"}/assets/styles`,
+                basePath: `./${eleventyConfig.dir.input || "src"}/assets/styles`,
                 enabled: false,
                 minify: true,
                 sourceMap: false,
@@ -66,15 +66,15 @@ module.exports = {
                 browserslist: "> 1%"
             },
             js: {
-                basePath: `${eleventyConfig.dir.input || "./src"}/assets/scripts`,
+                basePath: `./${eleventyConfig.dir.input || "src"}/assets/scripts`,
                 enabled: true,
                 minify: true,
                 target: "es2020",
-                outdir: `${eleventyConfig.dir.output || "./_site"}/assets/scripts`
+                outdir: `./${eleventyConfig.dir.output || "_site"}/assets/scripts`
             },
             supportedLanguages: languages,
             defaultLanguage: "en",
-            localesDirectory: `${eleventyConfig.dir.input || "./src"}/locales`,
+            localesDirectory: `./${eleventyConfig.dir.input || "src"}/locales`,
             templateFormats: [
                 "html",
                 "md",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   },
   "main": "index.js",
   "scripts": {
-    "build": "rimraf dist && eleventy",
+    "build": "rimraf _site && eleventy",
     "coverage": "c8 -r text -r lcov -x \"test/*.js\" -x \"eleventy.config.js\" -x \"fixtures/**/*.js\" ava",
     "lint": "fluid-lint-all",
-    "start": "rimraf dist && eleventy --serve",
+    "start": "rimraf _site && eleventy --serve",
     "test": "ava",
     "prepare": "husky install"
   },

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -21,56 +21,56 @@ test.before(async function () {
 });
 
 test("Builds minified CSS from CSS", async function (t) {
-    let mainCss = fs.readFileSync("dist/assets/styles/app.css", "utf8");
-    let timelineCss = fs.readFileSync("dist/assets/styles/pages/timeline.css", "utf8");
+    let mainCss = fs.readFileSync("_site/assets/styles/app.css", "utf8");
+    let timelineCss = fs.readFileSync("_site/assets/styles/pages/timeline.css", "utf8");
     t.is(mainCss, "*{box-sizing:border-box}button{font-family:inherit;font-size:1rem}*+*{margin-top:var(--space,1em)}");
     t.is(timelineCss, ".timeline ul{padding-inline-start:0;list-style:none}");
 });
 
 test("Builds minified CSS from Sass", async function (t) {
-    let sassCss = fs.readFileSync("dist/assets/styles/sass.css", "utf8");
+    let sassCss = fs.readFileSync("_site/assets/styles/sass.css", "utf8");
     t.is(sassCss, "a{color:#600}mark{background-color:#f90}");
 });
 
 test("Builds minified JavaScript", async function (t) {
-    let appJs = fs.readFileSync("dist/assets/scripts/app.js", "utf8");
-    let nojsJs = fs.readFileSync("dist/assets/scripts/no-js.js", "utf8");
+    let appJs = fs.readFileSync("_site/assets/scripts/app.js", "utf8");
+    let nojsJs = fs.readFileSync("_site/assets/scripts/no-js.js", "utf8");
     t.is(appJs, "\"use strict\";(()=>{var s=(e,t)=>()=>(t||e((t={exports:{}}).exports,t),t.exports);var c=s((S,a)=>{\"use strict\";var m=function(e){let t=new Intl.PluralRules(\"en\",{type:\"ordinal\"}),r=new Map([[\"one\",\"st\"],[\"two\",\"nd\"],[\"few\",\"rd\"],[\"other\",\"th\"]]),n=t.select(e),o=r.get(n);return`${e}${o}`};a.exports=function(t,r=\"en\"){let n=new Date(new Date(t).toUTCString()),o={year:\"numeric\",month:\"long\",day:\"numeric\"};if(r.startsWith(\"en\")){let l=n.toLocaleDateString(r,o),d=/([A-Z]\\w+) ([0-9]{1,2}), ([0-9]{4})/g;return l.replace(d,($,p,w,g)=>`${p} ${m(w)}, ${g}`)}return n.toLocaleDateString(r,o)}});var u=s((q,i)=>{\"use strict\";var D=c();i.exports=D});var h=s((L,f)=>{var x=u();f.exports={year:x(Date.now())}});h();})();\n");
     t.is(nojsJs, "\"use strict\";(()=>{document.documentElement.className=\"js\";})();\n");
 });
 
 test("Renders Markdown via shortcode", async function (t) {
-    let testHtml = fs.readFileSync("dist/test.html", "utf8");
+    let testHtml = fs.readFileSync("_site/test.html", "utf8");
     t.true(testHtml.includes("<h1>eleventy-plugin-fluid</h1>"));
 });
 
 test("Doesn't render unsupported template language via shortcode", async function (t) {
-    let testHtml = fs.readFileSync("dist/test.html", "utf8");
+    let testHtml = fs.readFileSync("_site/test.html", "utf8");
     t.true(testHtml.includes("{{ 'This template language doesn't exist!' }}"));
 });
 
 test("Renders Markdown via filter", async function (t) {
-    let testHtml = fs.readFileSync("dist/test.html", "utf8");
+    let testHtml = fs.readFileSync("_site/test.html", "utf8");
     t.true(testHtml.includes("<p>Not much to see here!</p>"));
 });
 
 test("Generates English permalinks", async function (t) {
-    let englishPost = fs.readFileSync("dist/posts/introduction/index.html", "utf8");
+    let englishPost = fs.readFileSync("_site/posts/introduction/index.html", "utf8");
     t.true(englishPost.includes("<h1>Introduction</h1>"));
 
-    let english404 = fs.readFileSync("dist/404.html", "utf8");
+    let english404 = fs.readFileSync("_site/404.html", "utf8");
     t.true(english404.includes("<h1>Page Not Found</h1>"));
 });
 
 test("Generates French permalinks", async function (t) {
-    let frPost = fs.readFileSync("dist/fr/posts/introduction/index.html", "utf8");
+    let frPost = fs.readFileSync("_site/fr/posts/introduction/index.html", "utf8");
     t.true(frPost.includes("<h1>Introduction</h1>"));
 
-    let fr404 = fs.readFileSync("dist/fr/404.html", "utf8");
+    let fr404 = fs.readFileSync("_site/fr/404.html", "utf8");
     t.true(fr404.includes("<h1>Page non trouvée</h1>"));
 });
 
 test("Generates user-configured language permalinks", async function (t) {
-    let dePost = fs.readFileSync("dist/de/posts/einfuehrung/index.html", "utf8");
+    let dePost = fs.readFileSync("_site/de/posts/einfuehrung/index.html", "utf8");
     t.true(dePost.includes("<h1>Einführung</h1>"));
 });


### PR DESCRIPTION
This PR updates the default input and output paths to match those in Trivet (see https://github.com/fluid-project/trivet/pull/337/commits/be8b5954348a39bc6d8ae6a0d2af6a85a3897a4d) and also adjusts the configuration to match whatever is set in a project's Eleventy configuration.