### PR TITLE
fix: rely on data.locale for permalink generation

### DIFF
--- a/fixtures/pages/pages.11tydata.js
+++ b/fixtures/pages/pages.11tydata.js
@@ -1,15 +1,12 @@
 "use strict";
 
-const { EleventyI18nPlugin } = require("@11ty/eleventy");
 const { getLangDir } = require("rtl-detect");
 const { generatePermalink } = require("../../index.js");
 
 module.exports = {
     layout: "layouts/base.njk",
     eleventyComputed: {
-        lang: data => EleventyI18nPlugin.LangUtils.getLanguageCodeFromInputPath(data.page.inputPath),
-        langDir: data => getLangDir(data.lang),
-        locale: data => data.lang,
+        langDir: data => getLangDir(data.locale),
         permalink: data => {
             return generatePermalink(data, "pages");
         }

--- a/fixtures/posts/posts.11tydata.js
+++ b/fixtures/posts/posts.11tydata.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { EleventyI18nPlugin } = require("@11ty/eleventy");
 const { getLangDir } = require("rtl-detect");
 const { generatePermalink } = require("../../index.js");
 const i18n = require("eleventy-plugin-i18n-gettext");
@@ -8,9 +7,7 @@ const i18n = require("eleventy-plugin-i18n-gettext");
 module.exports = {
     layout: "layouts/base.njk",
     eleventyComputed: {
-        lang: data => EleventyI18nPlugin.LangUtils.getLanguageCodeFromInputPath(data.page.inputPath),
-        langDir: data => getLangDir(data.lang),
-        locale: data => data.lang,
+        langDir: data => getLangDir(data.locale),
         permalink: data => {
             const locale = data.locale;
             return generatePermalink(data, "posts", i18n._(locale, "posts"));

--- a/src/utils/generate-permalink.js
+++ b/src/utils/generate-permalink.js
@@ -17,8 +17,8 @@ const generatePermalink = (data, collectionType, collectionSlug, paginationSlug 
     }
 
     const eleventyConfig = new TemplateConfig();
-    const lang = data.lang || data.defaultLanguage;
-    const langSlug = data.supportedLanguages[lang].slug || lang;
+    const locale = data.locale || data.defaultLanguage;
+    const langSlug = data.supportedLanguages[locale].slug || locale;
     collectionSlug = collectionSlug || collectionType;
     const slugify = eleventyConfig.userConfig.getFilter("slugify");
 
@@ -26,23 +26,23 @@ const generatePermalink = (data, collectionType, collectionSlug, paginationSlug 
 
         /* If the page is a 404 page, return 404.html, optionally prepended with the language code. */
         if (data.page.fileSlug === "404") {
-            return (lang === data.defaultLanguage) ? "/404.html" : `/${langSlug}/404.html`;
+            return (locale === data.defaultLanguage) ? "/404.html" : `/${langSlug}/404.html`;
         }
 
         /** If the page is the index page, the base path, optionally prepended with the language code. */
-        if (data.page.fileSlug === lang || data.page.inputPath.endsWith("index.md")) {
-            return (lang === data.defaultLanguage) ? "/" : `/${langSlug}/`;
+        if (data.page.fileSlug === locale || data.page.inputPath.endsWith("index.md")) {
+            return (locale === data.defaultLanguage) ? "/" : `/${langSlug}/`;
         }
 
         /* If the page is not the index page, return the page title in a URL-safe format, optionally prepended with the language code. */
         const slug = slugify(data.title);
         if (data.hasOwnProperty("pagination") && data.pagination.pageNumber > 0) {
-            return (lang === data.defaultLanguage) ? `/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/` : `/${langSlug}/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/`;
+            return (locale === data.defaultLanguage) ? `/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/` : `/${langSlug}/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/`;
         }
-        return (lang === data.defaultLanguage) ? `/${slug}/` : `/${langSlug}/${slug}/`;
+        return (locale === data.defaultLanguage) ? `/${slug}/` : `/${langSlug}/${slug}/`;
     } else {
         const slug = slugify(data.title);
-        return (lang === data.defaultLanguage) ? `/${collectionSlug}/${slug}/` : `/${langSlug}/${collectionSlug}/${slug}/`;
+        return (locale === data.defaultLanguage) ? `/${collectionSlug}/${slug}/` : `/${langSlug}/${collectionSlug}/${slug}/`;
     }
 };
 


### PR DESCRIPTION
`eleventy-plugin-i18n-gettext` sets two variables based on the locale directory within the `enhance11tydata()` method:

- `locale`: language and country code, e.g. `en-CA` 
- `lang`: language code, e.g. `en`

This PR fixes an issue where a locale could not be matched because the search string was the short `lang` value (`en`) but the set of locales being searched was indexed using the full `locale (`en-CA`) value.
