### PR TITLE
fix: don't use generatePermalink in eleventyComputed block

### DIFF
--- a/fixtures/pages/pages.11tydata.js
+++ b/fixtures/pages/pages.11tydata.js
@@ -5,10 +5,10 @@ const { generatePermalink } = require("../../index.js");
 
 module.exports = {
     layout: "layouts/base.njk",
+    permalink: data => {
+        return generatePermalink(data, "pages");
+    },
     eleventyComputed: {
-        langDir: data => getLangDir(data.locale),
-        permalink: data => {
-            return generatePermalink(data, "pages");
-        }
+        langDir: data => getLangDir(data.locale)
     }
 };

--- a/src/utils/generate-permalink.js
+++ b/src/utils/generate-permalink.js
@@ -10,7 +10,7 @@ const TemplateConfig = require("@11ty/eleventy/src/TemplateConfig.js");
  *
  * @return {String} - The generated permalink.
  */
-const generatePermalink = (data, collectionType, collectionSlug, paginationSlug = "pages") => {
+const generatePermalink = (data, collectionType, collectionSlug, paginationSlug = "page") => {
     /* If this post is a "stub" with no localized title, we assume it does not exist and prevent it from building. */
     if (!data.hasOwnProperty("title")) {
         return false;


### PR DESCRIPTION
`generatePermalink` needs to be used outside of the `eleventyComputed` block, see [Computed data](https://www.11ty.dev/docs/data-computed/):

> It is important to note that Computed Data is computed right before templates are rendered. Therefore Computed Data cannot be used to modify the [special data properties used to configure templates](https://www.11ty.dev/docs/data-configuration/) (e.g. layout, pagination, tags etc.).