### PR TITLE
fix: normalize paths for compiled JS in console messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = {
                     if (!path.basename(item).startsWith("_")) {
                         await compileJs(item, options.js);
                         // eslint-disable-next-line no-console
-                        console.log(`[11ty] Writing ${options.js.outdir}/${path.basename(item)} from ${item}`);
+                        console.log(`[11ty] Writing ${path.normalize(options.js.outdir)}/${path.basename(item)} from ${item}`);
                     }
                 });
             });

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ module.exports = {
                     if (!path.basename(item).startsWith("_")) {
                         await compileJs(item, options.js);
                         // eslint-disable-next-line no-console
-                        console.log(`[11ty] Writing ${path.normalize(options.js.outdir)}/${path.basename(item)} from ${item}`);
+                        console.log(`[11ty] Writing ${path.join(options.js.outdir, path.basename(item))} from ${item}`);
                     }
                 });
             });


### PR DESCRIPTION
We output built paths for JavaScript; Eleventy normalizes paths for its built files so this PR uses `path.normalize` to make sure the paths are formatted the same (prior to this PR it was `./_site/`, now it is `_site` for both the JS files and the other Eleventy-built files).