### PR TITLE
feat: exclude CSS and Sass files from collections

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,11 @@ module.exports = {
             eleventyConfig.addTemplateFormats("css");
             eleventyConfig.addExtension("css", {
                 outputFileExtension: "css",
+                getData: async function () {
+                    return {
+                        eleventyExcludeFromCollections: true
+                    };
+                },
                 compile: async function (inputContent, inputPath) {
                     return await compileCss(inputContent, inputPath, options.css);
                 }
@@ -177,6 +182,11 @@ module.exports = {
             eleventyConfig.addTemplateFormats("scss");
             eleventyConfig.addExtension("scss", {
                 outputFileExtension: "css",
+                getData: async function () {
+                    return {
+                        eleventyExcludeFromCollections: true
+                    };
+                },
                 compile: async function (inputContent, inputPath) {
                     return await compileSass(inputContent, inputPath, options.sass, this);
                 }


### PR DESCRIPTION
Right now all CSS and Sass files matched by their respective compilers are added to Eleventy's collections, which means they can show up in unexpected places, e.g. in a [sitemap](https://github.com/fluid-project/trivet-monolingual/blob/main/src/sitemap.njk) (which uses `collections.all` to iterate through rendered pages). This PR explicitly excludes them from Eleventy's collections, which doesn't impact their rendering but prevents them from being accessed via collection logic.