### PR TITLE
feat: use custom slugs for permalinks if set

### DIFF
--- a/fixtures/pages/en/three-letter-acronym.md
+++ b/fixtures/pages/en/three-letter-acronym.md
@@ -1,0 +1,5 @@
+---
+title: Three Letter Acronym
+slug: tla
+---
+Hello!

--- a/src/utils/generate-permalink.js
+++ b/src/utils/generate-permalink.js
@@ -35,13 +35,13 @@ const generatePermalink = (data, collectionType, collectionSlug, paginationSlug 
         }
 
         /* If the page is not the index page, return the page title in a URL-safe format, optionally prepended with the language code. */
-        const slug = slugify(data.title);
+        const slug = data.slug || slugify(data.title);
         if (data.hasOwnProperty("pagination") && data.pagination.pageNumber > 0) {
             return (locale === data.defaultLanguage) ? `/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/` : `/${langSlug}/${slug}/${paginationSlug}/${data.pagination.pageNumber + 1}/`;
         }
         return (locale === data.defaultLanguage) ? `/${slug}/` : `/${langSlug}/${slug}/`;
     } else {
-        const slug = slugify(data.title);
+        const slug = data.slug || slugify(data.title);
         return (locale === data.defaultLanguage) ? `/${collectionSlug}/${slug}/` : `/${langSlug}/${collectionSlug}/${slug}/`;
     }
 };

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -67,6 +67,11 @@ test("Generates English permalinks", async function (t) {
     t.true(english404.includes("<h1>Page Not Found</h1>"));
 });
 
+test("Generates permalinks from a custom slug", async function (t) {
+    let tlaPage = fs.readFileSync("_site/tla/index.html", "utf8");
+    t.true(tlaPage.includes("<h1>Three Letter Acronym</h1>"));
+});
+
 test("Generates French permalinks", async function (t) {
     let frPost = fs.readFileSync("_site/fr/posts/introduction/index.html", "utf8");
     t.true(frPost.includes("<h1>Introduction</h1>"));


### PR DESCRIPTION
Right now permalinks are ALWAYS generated based on the a slugified version of the title. However, in some instances users may want to specify a different slug, for example to have a page for "Equitable Digital Systems" at `/eds`. This PR modifies `generatePermalink` so that it will use a `slug` in the front matter data if it exists rather than slugifying the title.